### PR TITLE
ci: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps"
+    groups:
+      actions:
+        patterns: ["*"]


### PR DESCRIPTION
Adds `.github/dependabot.yml` covering the `uv` and `github-actions` ecosystems, weekly.

Dev-dependency minor/patch bumps (pytest, pytest-cov, ruff, ty) are grouped into one PR per week; `click` gets its own PR so runtime changes stay reviewable individually. Action bumps are grouped.

Note: `actions/checkout` is at v4 and `astral-sh/setup-uv` at v6 here, so expect a catch-up PR on the first run.
🤖 Generated with [Claude Code](https://claude.com/claude-code)